### PR TITLE
Fix MonoBehaviour custom counter menu binding

### DIFF
--- a/Counters+/Installers/CountersInstaller.cs
+++ b/Counters+/Installers/CountersInstaller.cs
@@ -95,7 +95,7 @@ namespace CountersPlus.Installers
 
             Plugin.Logger.Debug($"Loading counter {settings.DisplayName}...");
 
-            if (typeof(R).BaseType == typeof(MonoBehaviour))
+            if (typeof(MonoBehaviour).IsAssignableFrom(typeof(R)))
             {
                 Container.BindInterfacesAndSelfTo<R>().FromNewComponentOnRoot().AsSingle().NonLazy();
             }
@@ -117,7 +117,7 @@ namespace CountersPlus.Installers
 
                 Plugin.Logger.Debug($"Loading counter {customCounter.Name}...");
 
-                if (counterType.BaseType == typeof(MonoBehaviour))
+                if (typeof(MonoBehaviour).IsAssignableFrom(counterType))
                 {
                     Container.BindInterfacesAndSelfTo(counterType).FromNewComponentOnRoot().AsSingle().NonLazy();
                 }

--- a/Counters+/Installers/MenuUIInstaller.cs
+++ b/Counters+/Installers/MenuUIInstaller.cs
@@ -30,9 +30,9 @@ namespace CountersPlus.Installers
                 if (customCounter.BSML != null && customCounter.BSML.HasType)
                 {
                     Type hostType = customCounter.BSML.HostType;
-                    if (hostType.BaseType == typeof(MonoBehaviour))
+                    if (typeof(MonoBehaviour).IsAssignableFrom(hostType))
                     {
-                        Container.Bind(hostType).WithId(customCounter.Name).FromComponentOnRoot().AsCached();
+                        Container.Bind(hostType).WithId(customCounter.Name).FromNewComponentOnNewGameObject().AsCached();
                     }
                     else
                     {


### PR DESCRIPTION
`FromComponentOnRoot` requires the object to already exist on the root, which is not correct in this case. The settings menu should be created here.

Use a new game object instead of root to allow Zenject to run the inject methods before enabling the MonoBehaviour. 

Changes to type checks cover the cases where the type is not directly inheriting `MonoBehaviour` (there are more layers in between).